### PR TITLE
إضافة دعم Raspberry Pi لاستضافة الموقع

### DIFF
--- a/RASPBERRY_PI_DEPLOYMENT.md
+++ b/RASPBERRY_PI_DEPLOYMENT.md
@@ -1,0 +1,158 @@
+# استضافة موقع Eco Technology على Raspberry Pi
+
+هذا الدليل يشرح كيفية استخدام جهاز Raspberry Pi لاستضافة موقع Eco Technology.
+
+## المتطلبات
+
+- جهاز Raspberry Pi (يُفضل الإصدار 4 أو أحدث مع ذاكرة 4GB على الأقل)
+- بطاقة SD بسعة 16GB أو أكثر
+- نظام Raspberry Pi OS (سابقاً Raspbian) مثبت على البطاقة
+- اتصال إنترنت مستقر
+- عنوان IP ثابت أو خدمة DDNS
+
+## خطوات الإعداد
+
+### 1. تثبيت متطلبات النظام
+
+```bash
+sudo apt update
+sudo apt upgrade -y
+sudo apt install -y nodejs npm git nginx
+```
+
+### 2. تثبيت Node.js الإصدار الأحدث (اختياري)
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt install -y nodejs
+```
+
+### 3. استنساخ المشروع من GitHub
+
+```bash
+cd /home/pi
+git clone https://github.com/Binz2008/ecotech-landing.git
+cd ecotech-landing
+```
+
+### 4. تثبيت تبعيات المشروع وبناء الموقع
+
+```bash
+npm install --legacy-peer-deps
+npm run build
+```
+
+### 5. إعداد Nginx كخادم ويب
+
+إنشاء ملف تكوين لموقع Eco Technology:
+
+```bash
+sudo nano /etc/nginx/sites-available/ecotech
+```
+
+أضف التكوين التالي:
+
+```nginx
+server {
+    listen 80;
+    server_name ecotech.local; # استبدل بعنوان النطاق الخاص بك أو IP
+
+    root /home/pi/ecotech-landing/dist;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+```
+
+تفعيل الموقع وإعادة تشغيل Nginx:
+
+```bash
+sudo ln -s /etc/nginx/sites-available/ecotech /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl restart nginx
+```
+
+### 6. إعداد خدمة النظام للتشغيل التلقائي (اختياري)
+
+إذا كنت ترغب في تشغيل خادم تطوير بدلاً من الإصدار المبني:
+
+```bash
+sudo nano /etc/systemd/system/ecotech.service
+```
+
+أضف المحتوى التالي:
+
+```ini
+[Unit]
+Description=Eco Technology Website
+After=network.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/ecotech-landing
+ExecStart=/usr/bin/npm run dev
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+تفعيل وتشغيل الخدمة:
+
+```bash
+sudo systemctl enable ecotech
+sudo systemctl start ecotech
+```
+
+### 7. إعداد اسم النطاق (اختياري)
+
+إذا كنت ترغب في استخدام اسم نطاق بدلاً من عنوان IP:
+
+1. قم بتسجيل اسم نطاق من مزود خدمة النطاقات
+2. قم بإعداد خدمة DDNS إذا لم يكن لديك عنوان IP ثابت
+3. قم بتوجيه اسم النطاق إلى عنوان IP الخاص بجهاز Raspberry Pi
+4. قم بتحديث ملف تكوين Nginx باسم النطاق الجديد
+
+## الأمان
+
+لتأمين الموقع، يُنصح بإعداد HTTPS باستخدام Let's Encrypt:
+
+```bash
+sudo apt install -y certbot python3-certbot-nginx
+sudo certbot --nginx -d your-domain.com
+```
+
+## الصيانة
+
+### تحديث الموقع
+
+لتحديث الموقع عند إجراء تغييرات:
+
+```bash
+cd /home/pi/ecotech-landing
+git pull
+npm install --legacy-peer-deps
+npm run build
+```
+
+### مراقبة الأداء
+
+يمكنك مراقبة أداء الخادم باستخدام:
+
+```bash
+htop
+```
+
+## الاعتبارات
+
+- **الأداء**: Raspberry Pi قد يكون أبطأ من خوادم الويب التقليدية، لذا يُنصح باستخدامه للمواقع ذات الحركة المنخفضة أو للاختبار.
+- **الاستقرار**: تأكد من وجود مصدر طاقة مستقر وتبريد مناسب لجهاز Raspberry Pi.
+- **النسخ الاحتياطي**: قم بإعداد نظام للنسخ الاحتياطي المنتظم لبطاقة SD.
+- **الأمان**: قم بتحديث النظام بانتظام وتأمين الجهاز ضد الوصول غير المصرح به.
+
+## الخلاصة
+
+استضافة موقع Eco Technology على Raspberry Pi يمكن أن تكون حلاً فعالاً من حيث التكلفة للبيئات التطويرية أو المواقع الصغيرة. ومع ذلك، للمواقع الإنتاجية ذات الحركة العالية، قد ترغب في النظر في خيارات استضافة أكثر قوة.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![React](https://img.shields.io/badge/React-19-blue?style=for-the-badge&logo=react)](https://reactjs.org/)
 [![Vite](https://img.shields.io/badge/Vite-6-purple?style=for-the-badge&logo=vite)](https://vitejs.dev/)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind-4-cyan?style=for-the-badge&logo=tailwindcss)](https://tailwindcss.com/)
+[![Raspberry Pi](https://img.shields.io/badge/Raspberry_Pi-Support-red?style=for-the-badge&logo=raspberrypi)](https://www.raspberrypi.org/)
 
 ## 🌟 **Live Website**
 
@@ -25,6 +26,7 @@ EcoTech is a professional investment landing page designed to attract investors 
 - 🔒 **Production-ready** - Security headers and SEO optimization
 - 📧 **Lead capture** - Working contact forms via Netlify Forms
 - 💬 **WhatsApp integration** - Direct communication channel
+- 🥧 **Raspberry Pi support** - Self-hosting option for local development
 
 ---
 
@@ -40,6 +42,7 @@ EcoTech is a professional investment landing page designed to attract investors 
 
 ### **Deployment**
 - **Netlify** - Static site hosting with forms
+- **Raspberry Pi** - Self-hosting option for local development
 - **Custom Domain Ready** - Professional branding
 - **CDN Optimized** - Global content delivery
 - **HTTPS Enabled** - Secure connections
@@ -80,6 +83,9 @@ pnpm run preview
 
 # Lint code
 pnpm run lint
+
+# Deploy to Raspberry Pi
+./deploy-to-raspberry.sh [IP-ADDRESS] [USERNAME]
 ```
 
 ---
@@ -104,6 +110,10 @@ ecotech-landing/
 │   ├── index.css         # Base styles
 │   └── main.jsx          # Application entry point
 ├── dist/                 # Production build output
+├── RASPBERRY_PI_DEPLOYMENT.md  # Raspberry Pi setup guide
+├── deploy-to-raspberry.sh      # Deployment script
+├── nginx-ecotech.conf          # Nginx configuration
+├── ecotech.service             # Systemd service file
 ├── package.json          # Dependencies and scripts
 ├── vite.config.js        # Vite configuration
 ├── tailwind.config.js    # Tailwind CSS configuration
@@ -199,6 +209,21 @@ ecotech-landing/
    - Add custom domain in Netlify settings
    - Update DNS records at your domain provider
 
+### **Raspberry Pi Deployment**
+
+1. **Prerequisites**:
+   - Raspberry Pi with Raspberry Pi OS installed
+   - Node.js and npm installed
+   - Nginx installed
+
+2. **Deploy using script**:
+   ```bash
+   ./deploy-to-raspberry.sh 192.168.1.100 pi
+   ```
+
+3. **Manual setup**:
+   - See [RASPBERRY_PI_DEPLOYMENT.md](./RASPBERRY_PI_DEPLOYMENT.md) for detailed instructions
+
 ### **Other Deployment Options**
 - **Vercel** - Zero-config deployment
 - **GitHub Pages** - Free static hosting
@@ -269,4 +294,3 @@ This project is proprietary and confidential. All rights reserved.
 ---
 
 **Built with ❤️ for sustainable business growth in the UAE** 🇦🇪
-

--- a/deploy-to-raspberry.sh
+++ b/deploy-to-raspberry.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# سكريبت لنشر موقع Eco Technology على Raspberry Pi
+# استخدم: ./deploy-to-raspberry.sh [عنوان-IP] [اسم-المستخدم]
+
+# التحقق من المعلمات
+if [ "$#" -lt 2 ]; then
+    echo "الاستخدام: $0 [عنوان-IP-الخاص-بـ-Raspberry-Pi] [اسم-المستخدم]"
+    echo "مثال: $0 192.168.1.100 pi"
+    exit 1
+fi
+
+RASPBERRY_IP=$1
+RASPBERRY_USER=$2
+REMOTE_DIR="/home/$RASPBERRY_USER/ecotech-landing"
+
+echo "جاري بناء المشروع..."
+npm run build
+
+if [ $? -ne 0 ]; then
+    echo "فشل بناء المشروع. الرجاء التحقق من الأخطاء وإعادة المحاولة."
+    exit 1
+fi
+
+echo "جاري التحقق من الاتصال بـ Raspberry Pi..."
+ssh -q $RASPBERRY_USER@$RASPBERRY_IP exit
+if [ $? -ne 0 ]; then
+    echo "لا يمكن الاتصال بـ Raspberry Pi. الرجاء التحقق من عنوان IP واسم المستخدم."
+    exit 1
+fi
+
+echo "جاري التحقق من وجود المجلد على Raspberry Pi..."
+ssh $RASPBERRY_USER@$RASPBERRY_IP "if [ ! -d $REMOTE_DIR ]; then mkdir -p $REMOTE_DIR; fi"
+
+echo "جاري نقل الملفات إلى Raspberry Pi..."
+rsync -avz --delete dist/ $RASPBERRY_USER@$RASPBERRY_IP:$REMOTE_DIR/dist/
+rsync -avz package.json $RASPBERRY_USER@$RASPBERRY_IP:$REMOTE_DIR/
+
+echo "جاري تثبيت التبعيات على Raspberry Pi..."
+ssh $RASPBERRY_USER@$RASPBERRY_IP "cd $REMOTE_DIR && npm install --production --legacy-peer-deps"
+
+echo "جاري إعادة تشغيل خدمة Nginx..."
+ssh $RASPBERRY_USER@$RASPBERRY_IP "sudo systemctl restart nginx"
+
+echo "تم نشر الموقع بنجاح على Raspberry Pi!"
+echo "يمكنك الوصول إلى الموقع من خلال: http://$RASPBERRY_IP"
+
+exit 0

--- a/ecotech.service
+++ b/ecotech.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Eco Technology Website Service
+After=network.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/ecotech-landing
+ExecStart=/usr/bin/npm run dev
+Restart=on-failure
+RestartSec=10
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=ecotech-website
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=multi-user.target

--- a/nginx-ecotech.conf
+++ b/nginx-ecotech.conf
@@ -1,0 +1,65 @@
+server {
+    listen 80;
+    server_name ecotech.local; # استبدل بعنوان النطاق الخاص بك أو IP
+
+    root /home/pi/ecotech-landing/dist;
+    index index.html;
+
+    # تكوين للتطبيق أحادي الصفحة (SPA)
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # تحسين أداء الملفات الثابتة
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 30d;
+        add_header Cache-Control "public, no-transform";
+    }
+
+    # منع الوصول إلى الملفات المخفية
+    location ~ /\. {
+        deny all;
+        access_log off;
+        log_not_found off;
+    }
+
+    # سجلات الخطأ والوصول
+    access_log /var/log/nginx/ecotech-access.log;
+    error_log /var/log/nginx/ecotech-error.log;
+}
+
+# إعداد HTTPS (يتم تفعيله بعد الحصول على شهادة SSL)
+# server {
+#     listen 443 ssl http2;
+#     server_name ecotech.local;
+#
+#     ssl_certificate /etc/letsencrypt/live/ecotech.local/fullchain.pem;
+#     ssl_certificate_key /etc/letsencrypt/live/ecotech.local/privkey.pem;
+#     ssl_protocols TLSv1.2 TLSv1.3;
+#     ssl_prefer_server_ciphers on;
+#     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+#     ssl_session_timeout 1d;
+#     ssl_session_cache shared:SSL:10m;
+#     ssl_session_tickets off;
+#
+#     root /home/pi/ecotech-landing/dist;
+#     index index.html;
+#
+#     location / {
+#         try_files $uri $uri/ /index.html;
+#     }
+#
+#     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+#         expires 30d;
+#         add_header Cache-Control "public, no-transform";
+#     }
+#
+#     location ~ /\. {
+#         deny all;
+#         access_log off;
+#         log_not_found off;
+#     }
+#
+#     access_log /var/log/nginx/ecotech-access.log;
+#     error_log /var/log/nginx/ecotech-error.log;
+# }


### PR DESCRIPTION
هذا الطلب يضيف دعم استضافة موقع Eco Technology على أجهزة Raspberry Pi، مما يوفر خيار استضافة محلي منخفض التكلفة للتطوير والاختبار. يتضمن:

- دليل تفصيلي للإعداد والتثبيت
- سكريبت نشر تلقائي
- ملف تكوين Nginx
- ملف خدمة systemd للتشغيل التلقائي
- تحديث ملف README.md لتضمين معلومات عن دعم Raspberry Pi